### PR TITLE
Bugfix for when temperature sensor reading exceeds highest mapped value in temperature map.

### DIFF
--- a/src/pwm.c
+++ b/src/pwm.c
@@ -261,7 +261,7 @@ double pwm_map(const struct pwm_map *map, double val)
 
 	// find the map points that the value falls in between of...
 	i = 1;
-	while(i < map->points && map->pwm[i][0] < val)
+	while(i < map->points-1 && map->pwm[i][0] < val)
 		i++;
 
 	// value is larger or equal than last map point

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -108,7 +108,7 @@ double sensor_get_duty(const struct temp_map *map, double temp)
 		return map->temp[0][1];
 
 	i = 1;
-	while (i < map->points && map->temp[i][0] < t)
+	while (i < map->points-1 && map->temp[i][0] < t)
 		i++;
 
 	if (t >= map->temp[i][0])

--- a/src/tacho.c
+++ b/src/tacho.c
@@ -344,7 +344,7 @@ double tacho_map(const struct tacho_map *map, double val)
 
 	/* Find the map points that the value falls in between of... */
 	i = 1;
-	while(i < map->points && map->tacho[i][0] < val)
+	while(i < map->points-1 && map->tacho[i][0] < val)
 		i++;
 
 	/* Value is larger or equal than last map point */


### PR DESCRIPTION
Fixed bug which allowed i to be incremented past the end of the array in various functions: pwm_map(), tacho_map(), get_sensor_duty(). This can cause fan speeds to drop to minimum when temperature of a sensor exceeds the highest value in the temperature map. For example, setting CONF:SENSOR1:TEMPMAP 25,20,50,100 would result in 0% fan speed when temperature exceeds 50C.