### PR TITLE
Add ADC Vref as sensor 4 / Add timestamp to mqtt

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1470,6 +1470,35 @@ int cmd_sensor_ther_nominal(const char *cmd, const char *args, int query, char *
 	return 1;
 }
 
+int  cmd_sensor_adc_vref(const char *cmd, const char *args, int query, char *prev_cmd)
+{
+	int sensor;
+	float val;
+
+	sensor = atoi(&prev_cmd[6]) - 1; //all sensors on ADC share same adc_Vref so really a don't care
+	if ((sensor <= 0) || (sensor >= SENSOR_COUNT)) { 
+		log_msg(LOG_WARNING, "invalid sensor %d", sensor + 1);
+		return 2;
+	}
+	if (query) {
+		printf("%.2f\n", conf->adc_vref);
+		return 0;
+	} else if (str_to_float(args, &val)) {
+		if (val > 0.0) {
+			log_msg(LOG_NOTICE, "change adc voltage reference from %.2f volts --> %.2f volts",
+					conf->adc_vref,
+					val);
+			conf->adc_vref = val;
+			return 0;
+		} else {
+		    log_msg(LOG_WARNING, "sensor%d: invalid adc voltage reference: %f",
+					sensor + 1, val);
+			return 2;
+		}
+	}
+    return 1;
+}
+
 int cmd_sensor_beta_coef(const char *cmd, const char *args, int query, char *prev_cmd)
 {
 	int sensor;
@@ -2648,6 +2677,7 @@ const struct cmd_t sensor_c_commands[] = {
 	{ "TEMPNominal", 5, NULL,            cmd_sensor_temp_nominal },
 	{ "TEMPOffset",  5, NULL,            cmd_sensor_temp_offset },
 	{ "THERmistor",  4, NULL,            cmd_sensor_ther_nominal },
+	{ "VREFadc",     4, NULL,            cmd_sensor_adc_vref },
 	{ 0, 0, 0, 0 }
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -494,6 +494,7 @@ void clear_config(struct fanpico_config *cfg)
 	cfg->local_echo = false;
 	cfg->spi_active = false;
 	cfg->serial_active = false;
+	cfg->adc_vref = ADC_REF_VOLTAGE; //Zitt
 	cfg->led_mode = 0;
 	strncopy(cfg->name, "fanpico1", sizeof(cfg->name));
 	strncopy(cfg->display_type, "default", sizeof(cfg->display_type));
@@ -564,6 +565,7 @@ cJSON *config_to_json(const struct fanpico_config *cfg)
 	cJSON_AddItemToObject(config, "led_mode", cJSON_CreateNumber(cfg->led_mode));
 	cJSON_AddItemToObject(config, "spi_active", cJSON_CreateNumber(cfg->spi_active));
 	cJSON_AddItemToObject(config, "serial_active", cJSON_CreateNumber(cfg->serial_active));
+	cJSON_AddItemToObject(config, "adc_vref", cJSON_CreateNumber(cfg->adc_vref)); //Zitt
 	if (strlen(cfg->display_type) > 0)
 		cJSON_AddItemToObject(config, "display_type", cJSON_CreateString(cfg->display_type));
 	if (strlen(cfg->display_theme) > 0)
@@ -846,6 +848,10 @@ int json_to_config(cJSON *config, struct fanpico_config *cfg)
 		cfg->spi_active = cJSON_GetNumberValue(ref);
 	if ((ref = cJSON_GetObjectItem(config, "serial_active")))
 		cfg->serial_active = cJSON_GetNumberValue(ref);
+	//Zitt: BEGIN
+	if ((ref = cJSON_GetObjectItem(config, "adc_vref")))	
+	    cfg->adc_vref = cJSON_GetNumberValue(ref);
+	//Zitt: END
 	if ((ref = cJSON_GetObjectItem(config, "display_type"))) {
 		if ((val = cJSON_GetStringValue(ref)))
 			strncopy(cfg->display_type, val, sizeof(cfg->display_type));

--- a/src/fanpico.h
+++ b/src/fanpico.h
@@ -213,6 +213,7 @@ struct fanpico_config {
 	char timezone[64];
 	bool spi_active;
 	bool serial_active;
+	float adc_vref;
 #ifdef WIFI_SUPPORT
 	char wifi_ssid[WIFI_SSID_MAX_LEN + 1];
 	char wifi_passwd[WIFI_PASSWD_MAX_LEN + 1];

--- a/src/httpd-fs/index.shtml
+++ b/src/httpd-fs/index.shtml
@@ -70,6 +70,7 @@
 			<tr><!--#sensrow1--></tr>
 			<tr><!--#sensrow2--></tr>
 			<tr><!--#sensrow3--></tr>
+			<tr><!--#adcvrefrow1--></tr>
 		      </table>
 		  </td></tr>
 		</table>

--- a/src/httpd.c
+++ b/src/httpd.c
@@ -79,6 +79,11 @@ u16_t csv_stats(char *insert, int insertlen, u16_t current_tag_part, u16_t *next
 				pwm);
 			strncatenate(buf, row, BUF_LEN);
 		}
+		snprintf(row, sizeof(row), "sensor%d,\"%s\",%.3lf\n",
+				4,
+				"ADC VRef",
+				cfg->adc_vref);
+		strncatenate(buf, row, BUF_LEN);
 		for (i = 0; i < VSENSOR_COUNT; i++) {
 			pwm = sensor_get_duty(&cfg->vsensors[i].map, st->vtemp[i]);
 			snprintf(row, sizeof(row), "vsensor%d,\"%s\",%.1lf,%.1lf\n",
@@ -303,6 +308,13 @@ u16_t fanpico_ssi_handler(const char *tag, char *insert, int insertlen,
 					cfg->sensors[i].name,
 					st->temp[i]);
 		}
+	}
+	else if (!strncmp(tag, "adcvrefrow", 10)) {
+		//uint8_t i = tag[7] - '1';
+		printed = snprintf(insert, insertlen, "<td>%s<td>%s<td align=\"right\">%0.3f V",
+					"",
+					"ADC VRef",
+					cfg->adc_vref);
 	}
 	else if (!strncmp(tag, "vsenrow", 7)) {
 		uint8_t i = tag[7] - '1';

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -34,6 +34,7 @@
 #include "lwip/altcp_tls.h"
 #endif
 #endif
+#include "pico/util/datetime.h"
 
 #include "fanpico.h"
 
@@ -378,6 +379,7 @@ char* json_status_message()
 	cJSON *json, *l, *o;
 	int i;
 	float rpm;
+	datetime_t t;
 
 	if (!(json = cJSON_CreateObject()))
 		goto panic;
@@ -427,6 +429,14 @@ char* json_status_message()
 		cJSON_AddItemToArray(l, o);
 	}
 
+	if ( rtc_get_datetime(&t) ) {
+		/* Send Data Time stamp to broker for possible use */
+		char datetime_buf[256];
+        char *datetime_str = &datetime_buf[0];
+
+		datetime_to_str(datetime_str, sizeof(datetime_buf), &t);
+		cJSON_AddItemToObject(json, "date time", cJSON_CreateString( datetime_str ));
+	} else log_msg(LOG_WARNING,"rtc_get_datetime(): failed");
 
 	if (!(buf = cJSON_Print(json)))
 		goto panic;

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -46,6 +46,7 @@ double get_temperature(uint8_t input, const struct fanpico_config *config)
 	double t, r, volt;
 	int i;
 	const struct sensor_input *sensor;
+	const float adc_vref = config->adc_vref;
 
 	if (input >= SENSOR_COUNT)
 		return 0.0;
@@ -60,7 +61,7 @@ double get_temperature(uint8_t input, const struct fanpico_config *config)
 		raw += adc_read();
 	}
 	raw /= ADC_AVG_WINDOW;
-	volt = raw * (ADC_REF_VOLTAGE / ADC_MAX_VALUE);
+	volt = raw * (adc_vref / ADC_MAX_VALUE);
 
 	if (sensor->type == TEMP_INTERNAL) {
 		t = 27.0 - ((volt - 0.706) / 0.001721);


### PR DESCRIPTION
Add ADC Vref as sensor 4.
    Allows the Vref to be measured and recorded as a constant for more accurate  temperature sensor measurements.
    
Add Timestamp to mqtt messages
    for broker and consumers of the data stream to "know" how old the data is on the broker.    