### PR TITLE
Fix OLED initialization hanging on SDK 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 
 project(fanpico
-  VERSION 1.7.1
+  VERSION 1.7.2
   DESCRIPTION "FanPico - Programmable PWM (PC) Fan Controller"
   HOMEPAGE_URL https://kokkonen.net/fanpico/
   LANGUAGES C CXX ASM

--- a/src/display_oled.c
+++ b/src/display_oled.c
@@ -185,7 +185,7 @@ void oled_display_init()
 	do {
 		sleep_ms(50);
 		res = oledInit(&oled, dtype, -1, flip, invert, I2C_HW,
-			SDA_PIN, SCL_PIN, LCD_RESET_PIN, 0);
+			SDA_PIN, SCL_PIN, LCD_RESET_PIN, cfg->i2c_speed, true);
 	} while (res == OLED_NOT_FOUND && retries++ < 10);
 
 	if (res == OLED_NOT_FOUND) {


### PR DESCRIPTION
- Use updated ss_oled-lib that doesn't hang on SDK 2.1.0
- Disable WiFi Power Management