### PR TITLE
Fix panic on boot if SNMP community string was too long.

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -3051,7 +3051,9 @@ Server Room
 
 
 #### SYStem:SNMP:WRITecommunity
-Set SNMP (write) community name. (Default: private)
+Set SNMP (write) community name. (Default: <empty>)
+
+Note, when this is set to empty value (string), SNMP write access is disabled.
 
 Example:
 ```

--- a/src/config.c
+++ b/src/config.c
@@ -633,7 +633,7 @@ void clear_config(struct fanpico_config *cfg)
 	cfg->telnet_pwhash[0] = 0;
 	cfg->snmp_active = 0;
 	strncopy(cfg->snmp_community, "public", sizeof(cfg->snmp_community));
-	strncopy(cfg->snmp_community_write, "private", sizeof(cfg->snmp_community_write));
+	cfg->snmp_community_write[0] = 0;
 	cfg->snmp_contact[0] = 0;
 	cfg->snmp_location[0] = 0;
 	cfg->snmp_community_trap[0] = 0;

--- a/src/fanpico.h
+++ b/src/fanpico.h
@@ -286,11 +286,11 @@ struct fanpico_config {
 	char telnet_user[16 + 1];
 	char telnet_pwhash[128 + 1];
 	bool snmp_active;
-	char snmp_community[32 + 1];
-	char snmp_community_write[32 + 1];
+	char snmp_community[SNMP_MAX_COMMUNITY_STR_LEN + 1];
+	char snmp_community_write[SNMP_MAX_COMMUNITY_STR_LEN + 1];
 	char snmp_contact[32 + 1];
 	char snmp_location[32 + 1];
-	char snmp_community_trap[32 + 1];
+	char snmp_community_trap[SNMP_MAX_COMMUNITY_STR_LEN + 1];
 	bool snmp_auth_traps;
 	ip_addr_t snmp_trap_dst;
 #endif

--- a/src/lwipopts.h
+++ b/src/lwipopts.h
@@ -84,6 +84,7 @@ void pico_set_system_time(long int sec);
 #define SNMP_LWIP_MIB2                  1
 #define LWIP_STATS                      1
 #define MIB2_STATS                      1
+#define SNMP_MAX_COMMUNITY_STR_LEN      32
 
 #if TLS_SUPPORT
 #define HTTPD_ENABLE_HTTPS              1


### PR DESCRIPTION
- Fix "community string is too long!" panic during boot, if SNMP community string was too long.
- Disable SNMP writes, if write community is set to empty (string).